### PR TITLE
Remove batch_size feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Present
+
+- Remove `batch_size` argument
+
 # 0.0.4
 
 - Remove the ActiveRecord::Relation patch

--- a/README.md
+++ b/README.md
@@ -119,20 +119,6 @@ It's also possible to make prelude definitions that return a `Hash` with a
 when it's not convenient to build the entire hash up front. (See example in the
 'Arguments' section)
 
-### Batching
-
-It's possible to set a batch size when defining a prelude method so that
-records are fetched at max in groups of that size. The preloader will choose
-the order of batches to load based on the order of data access.
-
-``` ruby
-define_prelude :expensive_calculation, batch_size: 500 do |breweries|
-  # ...
-end
-```
-
-The default batch size contains all records.
-
 ### Arguments
 
 Prelude methods can also be defined to take in arguments. In this case, your

--- a/lib/prelude/method.rb
+++ b/lib/prelude/method.rb
@@ -1,9 +1,6 @@
 module Prelude
   class Method
-    attr_reader :batch_size
-
-    def initialize(batch_size:, &blk)
-      @batch_size = batch_size
+    def initialize(&blk)
       @definition = blk
     end
 

--- a/lib/prelude/preloadable.rb
+++ b/lib/prelude/preloadable.rb
@@ -14,8 +14,8 @@ module Prelude
       end
 
       # Define how to preload a given method
-      def define_prelude(name, batch_size: nil, &blk)
-        prelude_methods[name] = Prelude::Method.new(batch_size: batch_size, &blk)
+      def define_prelude(name, &blk)
+        prelude_methods[name] = Prelude::Method.new(&blk)
 
         define_method(name) do |*args|
           unless @prelude_preloader

--- a/spec/prelude_spec.rb
+++ b/spec/prelude_spec.rb
@@ -129,42 +129,6 @@ describe Prelude do
     ])
   end
 
-  it 'should be able to set a batch size' do
-    call_count = 0
-
-    klass = Class.new(ActiveRecord::Base) do
-      self.table_name = 'breweries'
-
-      define_prelude(:number, batch_size: 2) do |records|
-        call_count += 1
-        Hash[records.map { |r| [r, 42] }]
-      end
-    end
-
-    values = 4.times.map { klass.new }.map.with_prelude { |r| r.number }
-
-    expect(values.uniq).to eq([42])
-    expect(call_count).to eq(4 / 2) # one per batch
-  end
-
-  it 'should be able to use batch_size with default_proc' do
-    call_count = 0
-
-    klass = Class.new(ActiveRecord::Base) do
-      self.table_name = 'breweries'
-
-      define_prelude(:number, batch_size: 2) do |records|
-        call_count += 1
-        Hash.new { |h, k| h[k] = 42 }
-      end
-    end
-
-    values = 4.times.map { klass.new }.map.with_prelude { |r| r.number }
-
-    expect(values.uniq).to eq([42])
-    expect(call_count).to eq(4 / 2) # one per batch
-  end
-
   it 'should preload when called explicitly' do
     call_count = 0
     klass = Class.new do


### PR DESCRIPTION
We've been re-thinking `batch_size` as a feature for the base version of
this Gem. There are other ways to approach batching, and we haven't
particularly seen this as a use case in our apps yet, so removing it for
now.

cc / @jhawthorn
