### PR TITLE
move properties to instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Present
 
-- Remove `batch_size` argument
+- Remove `batch_size` argument (breaking change)
+- Move storage of resolved values into instances
 
 # 0.0.4
 

--- a/lib/prelude/preloadable.rb
+++ b/lib/prelude/preloadable.rb
@@ -7,6 +7,15 @@ module Prelude
 
     attr_writer :prelude_preloader
 
+    def preloaded_values
+      @preloaded_values ||= {}
+    end
+
+    def set_preloaded_value_for(name, args, result)
+      key = [name, args]
+      preloaded_values[key] = result
+    end
+
     class_methods do
       # Mapping of field name to block for resolving a given preloader
       def prelude_methods
@@ -18,11 +27,15 @@ module Prelude
         prelude_methods[name] = Prelude::Method.new(&blk)
 
         define_method(name) do |*args|
+          key = [name, args]
+          return preloaded_values[key] if preloaded_values.key?(key)
+
           unless @prelude_preloader
             @prelude_preloader = Preloader.new(self.class, [self])
           end
 
-          @prelude_preloader.fetch(name, self, *args)
+          @prelude_preloader.fetch(name, *args)
+          preloaded_values[key]
         end
       end
     end

--- a/lib/prelude/preloader.rb
+++ b/lib/prelude/preloader.rb
@@ -3,46 +3,25 @@ module Prelude
     def initialize(klass, records)
       @klass = klass
       @records = records
-      @runs = {}
     end
 
-    def fetch(name, object, *args)
+    def fetch(name, *args)
       method = @klass.prelude_methods.fetch(name)
 
-      # If this object has a run, return the value
-      if run = run_for(method, args)
-        return run[object]
+      # Load and set the results for each record
+      results = preload(method, args)
+      @records.each do |record|
+        record.set_preloaded_value_for(name, args, results[record])
       end
 
-      # Choose a run for the arguments that we're trying to load
-      run = preload(method, @records, args)
-
-      # Return the value for this object
-      run[object]
+      results
     end
 
     private
 
     # Preload the given field with the given args for all records
-    def preload(method, records, args)
-      results = method.call(records, *args)
-
-      # set the run for each of these name/record/args combos
-      records.each do |record|
-        set_run_for(method, args, results)
-      end
-
-      # Return the run
-      results
-    end
-
-    def run_for(method, args)
-      @runs.dig(method, args)
-    end
-
-    def set_run_for(method, args, run)
-      @runs[method] ||= {}
-      @runs[method][args] = run
+    def preload(method, args)
+      method.call(@records, *args)
     end
   end
 end


### PR DESCRIPTION
Move the tracking of values into instances

Rather than maintain the mapping of instances to values inside of the
`Preloader`, this commit moves the tracking into the individual
instances.

This is nice in the case that an object is used with multiple batches,
but also makes the code much clearer to reason about.

Note: If an object is run in two separate batches with the same method
name, it'll re-run the fetch call. This can be fixed in a follow-on PR.

Co-authored-by: John Hawthorn <john@hawthorn.email>
