### PR TITLE
Add ability to define an inverse method

### DIFF
--- a/lib/prelude.rb
+++ b/lib/prelude.rb
@@ -4,6 +4,8 @@ require_relative 'prelude/enumerator'
 require 'active_support'
 
 module Prelude
+  AmbiguousInverseError = Class.new(StandardError)
+
   def self.wrap(records)
     preloader = Preloader.new(records)
     records.each { |r| r.prelude_preloader = preloader }

--- a/lib/prelude/preloadable.rb
+++ b/lib/prelude/preloadable.rb
@@ -29,7 +29,7 @@ module Prelude
       end
 
       # Define how to preload a given method
-      def define_prelude(name, &blk)
+      def define_prelude(name, inverse: nil, &blk)
         prelude_methods[name] = Prelude::Method.new(&blk)
 
         define_method(name) do |*args|
@@ -42,6 +42,19 @@ module Prelude
 
           @prelude_preloader.fetch(name, *args)
           preloaded_values[key]
+        end
+
+        if inverse
+          if blk.arity != 2
+            raise AmbiguousInverseError, "Can only define an inverse if 2 block parameters are passed to define_prelude"
+          end
+
+          # inverse is a tuple of [Class, inverse_name]
+          inverse_class, inverse_name = inverse
+          inverse_class.define_method(inverse_name) do |record|
+            # Call the batch method on the preloaded record
+            record.public_send(name, self)
+          end
         end
       end
     end


### PR DESCRIPTION
Currently, prelude requires that you define/call batch methods on the instances that would be the "N" part of an N+1 query.

Example:

```ruby
repositories.each.with_prelude do |repo|
  repo.starred_by?(current_user)
end
```

Sometimes it may feel more natural/elegant to flip this around:

```ruby
repositories.each.with_prelude do |repo|
  current_user.has_starred?(repo)
end
```

Another reason to have the inverse method could be to reduce churn in an existing large codebase where the "inverse" form of the method already has hundreds of callsites.

Why not just define the inverse method manually? That's a fair question. I think the only real benefit of this is the logical co-location of the inverse method with the batch method definition. On one hand, finding the definition of `User#has_starred?` may be harder. On the other hand, once you grep for `:has_starred?` you'll find it along with its inverse batch method definition, which is effectively the definition of the inverse method as well.

That all being said, there are some real tradeoffs here, and I'm not sure myself if the beneifts outweight the costs. Either way, this was fun to hack on and I learned more about prelude internals!