### PR TITLE
Add strict form of each prelude method that forbids N+1s

### DIFF
--- a/lib/prelude.rb
+++ b/lib/prelude.rb
@@ -4,6 +4,10 @@ require_relative 'prelude/enumerator'
 require 'active_support'
 
 module Prelude
+  # Raised when the strict form of a prelude method is called
+  # without a Preloader context.
+  class StrictLoadingViolationError < RuntimeError; end
+
   def self.wrap(records)
     preloader = Preloader.new(records)
     records.each { |r| r.prelude_preloader = preloader }

--- a/lib/prelude/preloadable.rb
+++ b/lib/prelude/preloadable.rb
@@ -31,22 +31,30 @@ module Prelude
       # Define how to preload a given method
       def define_prelude(name, &blk)
         prelude_methods[name] = Prelude::Method.new(&blk)
-        { name => false, "#{name}!" => true }.each do |method_name, strict|
-          define_method(method_name) do |*args|
-            key = [name, args]
-            return preloaded_values[key] if preloaded_values.key?(key)
 
-            unless @prelude_preloader
-              if strict
-                raise Prelude::StrictLoadingViolationError, "refusing to lazily initialize preloader, use `wrap` or `with_prelude`"
-              else
-                @prelude_preloader = Preloader.new([self])
-              end
-            end
+        define_method(name) do |*args|
+          key = [name, args]
+          return preloaded_values[key] if preloaded_values.key?(key)
 
-            @prelude_preloader.fetch(name, *args)
-            preloaded_values[key]
+          unless @prelude_preloader
+            @prelude_preloader = Preloader.new([self])
           end
+
+          @prelude_preloader.fetch(name, *args)
+          preloaded_values[key]
+        end
+
+        # strict form with ! suffix
+        define_method("#{name}!") do |*args|
+          key = [name, args]
+          return preloaded_values[key] if preloaded_values.key?(key)
+
+          unless @prelude_preloader
+            raise Prelude::StrictLoadingViolationError, "refusing to lazily initialize preloader, use `wrap` or `with_prelude`"
+          end
+
+          @prelude_preloader.fetch(name, *args)
+          preloaded_values[key]
         end
       end
     end


### PR DESCRIPTION
It's actually surprisingly possible in real world code to end up with an array mixed from several preloaded sources and some sources that are not preloaded at all, which can trigger N+1s on apparently preloaded data.

To make it possible to avoid this, add a strict form of each prelude method suffixed with `!` which raises `Prelude::StrictLoadingViolationError` if it is called in a way that would otherwise lazily inject a `Prelude::Preloader` instance (and thus be a likely source of inadvertent N+1s).