### PR TITLE
Add `Preloadable#preloaded`

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,3 +144,23 @@ define_prelude :has_admin? do |breweries, current_user|
   Hash.new { |h, brewery| admin_ids.include?(brewery.id) }
 end
 ```
+
+### Explicit preloading
+
+Sometimes it's useful to preload values before you need to use them.
+
+``` ruby
+Prelude.preload(comments, :body, format: :html)
+```
+
+Later, you can require Prelude to use the preloaded value:
+
+``` erb
+<% comments.each do |comment| %>
+  <%= comment.preloaded.body(format: :html) %>
+<% end %>
+```
+
+This prevents you from accidentally loading data twice by changing the arguments
+to the `Prelude.preload` call without also remembering to change the arguments
+to the `Comment#body` call in the view or vice versa.

--- a/lib/prelude/preloadable.rb
+++ b/lib/prelude/preloadable.rb
@@ -1,4 +1,5 @@
 require_relative './preloader'
+require_relative './preloaded'
 require_relative './method'
 
 module Prelude
@@ -14,6 +15,10 @@ module Prelude
     def set_preloaded_value_for(name, args, result)
       key = [name, args]
       preloaded_values[key] = result
+    end
+
+    def preloaded
+      Preloaded.new(self)
     end
 
     class_methods do

--- a/lib/prelude/preloaded.rb
+++ b/lib/prelude/preloaded.rb
@@ -1,30 +1,34 @@
 module Prelude
   class ValueNotPreloaded < StandardError; end
 
-  class Preloaded
+  class Preloaded < BasicObject
     def initialize(preloadable)
       @preloadable = preloadable
     end
 
     def method_missing(name, *args)
-      if respond_to_missing?(name, false)
-        fetch(name, *args)
+      if has_prelude_method?(name)
+        fetch_preloaded_value(name, *args)
       else
         super
       end
     end
 
-    def respond_to_missing?(name, include_private)
-      @preloadable.class.prelude_methods.has_key?(name) || super
+    def respond_to_missing?(name, include_private = false)
+      has_prelude_method?(name) || super
     end
 
     private
 
-    def fetch(name, *args)
+    def has_prelude_method?(name)
+      @preloadable.class.prelude_methods.has_key?(name)
+    end
+
+    def fetch_preloaded_value(name, *args)
       key = [name, args]
       @preloadable.preloaded_values.fetch(key)
-    rescue KeyError
-      raise ValueNotPreloaded,
+    rescue ::KeyError
+      ::Kernel.raise ::Prelude::ValueNotPreloaded,
         "#{@preloadable.inspect} has no preloaded value for method " +
         "##{name} with arguments #{args.inspect}"
     end

--- a/lib/prelude/preloaded.rb
+++ b/lib/prelude/preloaded.rb
@@ -1,0 +1,32 @@
+module Prelude
+  class ValueNotPreloaded < StandardError; end
+
+  class Preloaded
+    def initialize(preloadable)
+      @preloadable = preloadable
+    end
+
+    def method_missing(name, *args)
+      if respond_to_missing?(name, false)
+        fetch(name, *args)
+      else
+        super
+      end
+    end
+
+    def respond_to_missing?(name, include_private)
+      @preloadable.class.prelude_methods.has_key?(name) || super
+    end
+
+    private
+
+    def fetch(name, *args)
+      key = [name, args]
+      @preloadable.preloaded_values.fetch(key)
+    rescue KeyError
+      raise ValueNotPreloaded,
+        "#{@preloadable.inspect} has no preloaded value for method " +
+        "##{name} with arguments #{args.inspect}"
+    end
+  end
+end

--- a/spec/prelude_spec.rb
+++ b/spec/prelude_spec.rb
@@ -214,4 +214,28 @@ describe Prelude do
     expect(records.map { |record| record.foo(:arg2) }).to eq([:arg2]*4)
     expect(call_counts).to eq(arg1: 1, arg2: 1)
   end
+
+  it 'should require preloaded data' do
+    klass = Class.new do
+      include Prelude::Preloadable
+
+      define_prelude(:double) do |records, arg|
+        records.index_with(arg * 2)
+      end
+    end
+    record = klass.new
+
+    expect {
+      record.preloaded.double(3)
+    }.to raise_error(Prelude::ValueNotPreloaded)
+
+    Prelude.preload([record], :double, 3)
+
+    expect { record.preloaded.double(3) }.not_to raise_error
+    expect(record.preloaded.double(3)).to eq(6)
+
+    expect {
+      record.preloaded.double(2)
+    }.to raise_error(Prelude::ValueNotPreloaded)
+  end
 end


### PR DESCRIPTION
## What?

This PR introduces a `Prelude::Preloaded` object that will respond to any prelude method for a given preloadable object, and either return the value that has already been preloaded, or raise an exception.

It also introduces a `Prelude::Preloadable#preloaded` method to easily get a `Preloaded` instance for any preloadable object.

## Why?

This is useful in situations where data is explicitly preloaded before it is used, e.g.

``` ruby
Prelude.preload(records, :foo, mysterious_argument: 1)
records.each { |r| r.foo(mysterious_argument: 1) }
```

In this example changing the value of `mysterious_argument` in one line but not the other will result in the `foo` values being loaded twice (once for each argument value) even though only one set of values is used. In practice these two calls would likely be very far from each other, making it easy to change one call site and overlook the other.

The second line can be changed to only use preloaded values, preventing this type of regression:

``` ruby
records.each { |r| r.preloaded.foo(mysterious_argument: 1) }
```